### PR TITLE
feat(logger): Add Logger

### DIFF
--- a/example.php
+++ b/example.php
@@ -14,11 +14,11 @@ class MilchkuhDummyClass
             'host'       => 'localhost',
             'port'       => 3306,
             'user'       => 'root',
-            'pass'       => 'vagrant',
+            'pass'       => '',
             'db_name'    => 'test',
             'table_name' => 'milchkuh_test'
         ];
-        $this->init($db_info);
+        $this->init($db_info, __DIR__ . '/logs/query.log');
     }
 
     public function fetch()

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -19,6 +19,7 @@ class Exception extends \Exception
     const NO_TRANSACTION    = 8;
     const EXEC_ERROR        = 9;
     const CALL_ERROR        = 10;
+    const LOGFILE_DIR_ERROR = 11;
 
     /**
      * @var string  $query

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace chloe463\Milchkuh;
+
+class Logger
+{
+    /**
+     * @var string  $log_file_path
+     */
+    private $log_file_path;
+
+    /**
+     * Constructor
+     *
+     * @param   string  $log_file_path
+     * @codeCoverageIgnore
+     */
+    public function __construct($log_file_path)
+    {
+        $this->setLogFilePath($log_file_path);
+    }
+
+    /**
+     * Reset $log_file_path
+     */
+    public function setLogFilePath($log_file_path)
+    {
+        if (!file_exists(dirname($log_file_path))) {
+            throw new Exception('No such directory: '. dirname($log_file_path), '', [], Exception::LOGFILE_DIR_ERROR);
+        }
+        $this->log_file_path = $log_file_path;
+    }
+
+    /**
+     * Return $log_file_path
+     */
+    public function getLogFilePath()
+    {
+        return $this->log_file_path;
+    }
+
+    /**
+     * Log query to $log_file_path
+     *
+     * @param   string  $query
+     * @param   array   $bind_param
+     */
+    public function log($query)
+    {
+        error_log($this->buildMessage($query), 3, $this->log_file_path);
+    }
+
+    /**
+     * Build message to log
+     * Log format: [Y-m-d H:i:s] [pid] Message
+     *
+     * @param   string  $query
+     * @param   array   $bind_param
+     */
+    public function buildMessage($query)
+    {
+        $now = (new \DateTime())->format('Y-m-d H:i:s');
+        $pid = getmypid();
+
+        return sprintf("[%s] [%s] %s\n", $now, $pid, $query);
+    }
+}

--- a/src/Milchkuh.php
+++ b/src/Milchkuh.php
@@ -40,6 +40,11 @@ trait Milchkuh
     protected $row_count;
 
     /**
+     * @var Logger
+     */
+    protected $logger;
+
+    /**
      * Getters and setters
      */
     public function getConnectionInfo()
@@ -82,17 +87,27 @@ trait Milchkuh
         return $this->row_count;
     }
 
+    public function getLogger()
+    {
+        return $this->logger;
+    }
+
     /**
      * Initialize
      *
      * @param   array   $connection_info
      */
-    public function init($connection_info)
+    public function init($connection_info, $log_file_path = '')
     {
         $this->validateConnectionInfo($connection_info);
         $this->connection_info = $connection_info;
         $this->db_name         = $connection_info['db_name'];
         $this->table_name      = isset($connection_info['table_name']) ? $connection_info['table_name'] : '';
+
+        $this->logger = null;
+        if ($log_file_path !== '') {
+            $this->logger = new Logger($log_file_path);
+        }
 
         return;
     }
@@ -247,6 +262,9 @@ trait Milchkuh
      */
     public function prepare($query)
     {
+        if (!is_null($this->logger)) {
+            $this->logger->log($query);
+        }
         return $this->connect()->prepare($query);
     }
 

--- a/src/Milchkuh.php
+++ b/src/Milchkuh.php
@@ -260,7 +260,7 @@ trait Milchkuh
      *
      * @return  \PDOStatement
      */
-    public function prepare($query)
+    public function prepare($query, $bind_param)
     {
         if (!is_null($this->logger)) {
             $this->logger->log($query);
@@ -299,7 +299,7 @@ trait Milchkuh
             throw new Exception("Non-INSERT query is given to " . __METHOD__, $query, $bind_param, Exception::UNMATCHED_SQL);
         }
 
-        $statement = $this->prepare($query);
+        $statement = $this->prepare($query, $bind_param);
         $this->execute($statement, $bind_param);
 
         $this->last_insert_id = $this->dbh->lastInsertId();
@@ -323,7 +323,7 @@ trait Milchkuh
             throw new Exception("Non-SELECT query is given to " . __METHOD__, $query, $bind_param, Exception::UNMATCHED_SQL);
         }
 
-        $statement = $this->prepare($query);
+        $statement = $this->prepare($query, $bind_param);
         $this->execute($statement, $bind_param);
 
         $records = [];
@@ -353,7 +353,7 @@ trait Milchkuh
             throw new Exception("Non-UPDATE query is given to " . __METHOD__, $query, $bind_param, Exception::UNMATCHED_SQL);
         }
 
-        $statement = $this->prepare($query);
+        $statement = $this->prepare($query, $bind_param);
         $this->execute($statement, $bind_param);
 
         $row_count = $statement->rowCount();
@@ -376,7 +376,7 @@ trait Milchkuh
             throw new Exception("Non-DELETE query is given to " . __METHOD__, $query, $bind_param, Exception::UNMATCHED_SQL);
         }
 
-        $statement = $this->prepare($query);
+        $statement = $this->prepare($query, $bind_param);
         $this->execute($statement, $bind_param);
 
         $row_count = $statement->rowCount();
@@ -399,7 +399,7 @@ trait Milchkuh
             throw new Exception("Non-CALL query is given to " . __METHOD__, $query, $bind_param, Exception::UNMATCHED_SQL);
         }
 
-        $statement = $this->prepare($query);
+        $statement = $this->prepare($query, $bind_param);
         $this->execute($statement, $bind_param);
 
         $records = $statement->fetchAll(\PDO::FETCH_ASSOC);
@@ -418,7 +418,7 @@ trait Milchkuh
      */
     public function nap($seconds)
     {
-        $statement = $this->prepare("SELECT SLEEP({$seconds})");
+        $statement = $this->prepare("SELECT SLEEP({$seconds})", []);
         $this->execute($statement, []);
         $this->disconnect($statement);
         return true;

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace chloe463\Milchkuh;
+
+class LoggerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Logger
+     */
+    protected $object;
+
+    /**
+     * Called before a test run
+     */
+    public function setUp()
+    {
+        $this->object = new Logger(__DIR__ . '/logs/test.log');
+    }
+
+    /**
+     * Called after a test run
+     */
+    public function tearDown()
+    {
+        $this->object = null;
+        $file = __DIR__ . '/logs/test.log';
+        if (file_exists($file)) {
+            unlink($file);
+        }
+    }
+
+    /**
+     * @covers chloe463\Milchkuh\Logger::setLogFilePath
+     */
+    public function testSetLogFilePath()
+    {
+        $log_file_path   = __DIR__ . '/logs/test.log';
+        $expected_result = __DIR__ . '/logs/test.log';
+        $this->object->setLogFilePath(__DIR__. '/logs/test.log');
+        $actual_result   = $this->object->getLogFilePath();
+
+        $this->assertEquals($expected_result, $actual_result);
+    }
+
+    /**
+     * @covers chloe463\Milchkuh\Logger::setLogFilePath
+     */
+    public function testSetLogFilePath_throwsException()
+    {
+        $expected_result = 'No such directory: /path/to/no-such-directory';
+        $log_file_path = '/path/to/no-such-directory/file';
+        try {
+            $this->object->setLogFilePath($log_file_path);
+            $this->fail();
+        } catch (Exception $e) {
+            $this->assertEquals($expected_result, $e->getMessage());
+            $this->assertEquals(11, $e->getCode());
+        }
+    }
+
+    /**
+     * @covers chloe463\Milchkuh\Logger::getLogFilePath
+     */
+    public function testGetLogFilePath()
+    {
+        $expected_result = __DIR__ . '/logs/test.log';
+        $actual_result   = $this->object->getLogFilePath();
+
+        $this->assertEquals($expected_result, $actual_result);
+    }
+
+    /**
+     * @covers chloe463\Milchkuh\Logger::log
+     */
+    public function testLog()
+    {
+        $this->object->log('SELECT * FROM db.table');
+        $this->assertFileExists(__DIR__ . '/logs/test.log');
+    }
+
+    /**
+     * @covers chloe463\Milchkuh\Logger::buildMessage
+     */
+    public function testBuildMessage()
+    {
+        $expected_result = '/\[[0-9]{4}-[0-9]{2}-[0-9]{2}\s[0-9]{2}:[0-9]{2}:[0-9]{2}\]\s\[[0-9]+\]\sSELECT \* FROM db\.table/';
+        $actual_result   = $this->object->buildMessage('SELECT * FROM db.table');
+        $this->assertRegExp($expected_result, $actual_result);
+    }
+}

--- a/tests/MilchkuhTest.php
+++ b/tests/MilchkuhTest.php
@@ -90,6 +90,9 @@ SQL;
         );
         $statement = $dbh->prepare($query, []);
         $statement->execute([]);
+        if (file_exists(__DIR__ . '/logs/test.log')) {
+            unlink(__DIR__ . '/logs/test.log');
+        }
         $this->object = null;
     }
 

--- a/tests/MilchkuhTest.php
+++ b/tests/MilchkuhTest.php
@@ -20,7 +20,7 @@ class Milchkuh_dummy
             'db_name'    => $_ENV['DB_NAME'],
             'table_name' => $_ENV['DB_TABLE']
         ];
-        $this->init($connection_info);
+        $this->init($connection_info, __DIR__ . '/logs/test.log');
     }
 }
 
@@ -202,6 +202,14 @@ SQL;
     }
 
     /**
+     * @covers chloe463\Milchkuh\Milchkuh::getLogger
+     */
+    public function testGetLogger()
+    {
+        $this->assertInstanceOf('chloe463\Milchkuh\Logger', $this->object->getLogger());
+    }
+
+    /**
      * @covers chloe463\Milchkuh\Milchkuh::init
      */
     public function testInit()
@@ -219,6 +227,9 @@ SQL;
         $this->assertEquals($connection_info, $this->object->getConnectionInfo());
         $this->assertEquals($_ENV['DB_NAME'], $this->object->getDbName());
         $this->assertEquals($_ENV['DB_TABLE'], $this->object->getTableName());
+
+        $this->object->init($connection_info, __DIR__ . '/logs/test.log');
+        $this->assertInstanceOf('chloe463\Milchkuh\Logger', $this->object->getLogger());
     }
 
     /**

--- a/tests/MilchkuhTest.php
+++ b/tests/MilchkuhTest.php
@@ -72,7 +72,7 @@ SQL;
             $_ENV['DB_USER'],
             $_ENV['DB_PASS']
         );
-        $statement = $dbh->prepare($query);
+        $statement = $dbh->prepare($query, $new_record);
         $statement->execute($new_record);
         $this->test_record_id = $dbh->lastInsertId();
     }
@@ -88,7 +88,7 @@ SQL;
             $_ENV['DB_USER'],
             $_ENV['DB_PASS']
         );
-        $statement = $dbh->prepare($query);
+        $statement = $dbh->prepare($query, []);
         $statement->execute([]);
         $this->object = null;
     }
@@ -468,7 +468,7 @@ SQL;
      */
     public function testPrepare()
     {
-        $actual_result = $this->object->prepare('SELECT 1');
+        $actual_result = $this->object->prepare('SELECT 1', []);
         $this->assertInstanceOf('\PDOStatement', $actual_result);
     }
 
@@ -477,12 +477,12 @@ SQL;
      */
     public function testExecute()
     {
-        $statement     = $this->object->prepare('SELECT 1');
+        $statement     = $this->object->prepare('SELECT 1', []);
         $actual_result = $this->object->execute($statement, []);
         $this->assertTrue($actual_result);
 
         try {
-            $statement = $this->object->prepare('SELECT ?');
+            $statement = $this->object->prepare('SELECT ?', [1]);
             $this->object->execute($statement, []);
             $this->fail();
         } catch (Exception $e) {


### PR DESCRIPTION
## New Feature

* Add `chloe463\Milchkuh\Logger`
* Pass log file path to `chloe463\Milchkuh\Milchkuh::init` as 2nd argument to log queries and bind parameters
    ```php
    $this->init($connection_info, '/path/to/log-file');
    ```
* If the directory does not exist, it throws exception
* If `$log_file_path` is not given, `chloe463\Milchkuh\Milchkuh` is not log query
* The log format is `[YYYY-MM-DD HH:mm:ss] [pid] query`